### PR TITLE
replaced 'infra' with 'infrastructure'

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,12 +49,12 @@ local-docker-infrastructure-down = "docker compose stop"
 local-zenml-server-down = "pixi run zenml logout --local"
 local-zenml-server-up = { cmd = "pixi run zenml login --local", env = { OBJC_DISABLE_INITIALIZE_FORK_SAFETY = "YES" } }
 local-infrastructure-up= [
-  { task = "local-docker-infra-up" },
+  { task = "local-docker-infrastructure-up" },
   { task = "local-zenml-server-down" },
   { task = "local-zenml-server-up" },
 ]
 local-infrastructure-down = [
-  { task = "local-docker-infra-down" },
+  { task = "local-docker-infrastructure-down" },
   { task = "local-zenml-server-down" },
 ]
 set-local-stack = "pixi run zenml stack set default"


### PR DESCRIPTION
When I ran `pixi run local-infrastructure-up`, I got:
Error:   × could not find the task 'local-docker-**infra**-up'

Changing the words 'infra' to 'infrastructure' matches the 
commands above:
local-docker-**infrastructure**-up = "docker compose up -d"
and fixes the problem.

Thanks for putting this together; this is great!